### PR TITLE
fix(worker): install ca-certificates so the worker can reach Temporal Cloud

### DIFF
--- a/activities-examples/Dockerfile
+++ b/activities-examples/Dockerfile
@@ -1,5 +1,15 @@
 FROM node:bookworm-slim
 
+# node:bookworm-slim ships without the ca-certificates package, so /etc/ssl/certs
+# is empty. The Temporal SDK's native gRPC core (Rust/tonic via rustls-native-certs)
+# loads the OS trust store to verify Temporal Cloud's TLS certificate; without it
+# the worker dies on startup with:
+#   TransportError: tonic::transport::Error(Transport, NativeCertsNotFound)
+# Install the CA bundle so the worker can establish its TLS connection.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 # Set the working directory inside the container
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

The published worker images (`ghcr.io/sola-solutions/backend-interview/temporal-worker:v1` etc.) crash on startup against Temporal Cloud with:

```
TransportError: tonic::transport::Error(Transport, NativeCertsNotFound)
    at NativeConnection.connect (/app/node_modules/@temporalio/worker/lib/connection.js:199:23)
    at async run (/app/lib/worker.js:82:24)
```

## Root cause

`activities-examples/Dockerfile` is built `FROM node:bookworm-slim`, and the **slim** variant ships **without the `ca-certificates` package** — `/etc/ssl/certs` is empty (verified: `ls /etc/ssl/certs/` → *No such file or directory* in the running `v1` image).

The Temporal TypeScript SDK doesn't do gRPC in JS; it uses a native **Rust core (tonic + `rustls-native-certs`)**. Connecting to Temporal Cloud requires TLS (API-key auth implies it), and `rustls-native-certs` loads the **OS trust store** to verify the server certificate. With no CA bundle present, it returns `NativeCertsNotFound` and the worker dies before it can register with the `temporal-worker-controller`.

Note: `NODE_EXTRA_CA_CERTS` does **not** fix this — that only affects Node's own JS TLS, not the native core used for the gRPC connection.

## Fix

Install `ca-certificates` in the image:

```dockerfile
RUN apt-get update \
    && apt-get install -y --no-install-recommends ca-certificates \
    && rm -rf /var/lib/apt/lists/*
```

## Verification

- Confirmed the `v1` image is Debian 12 (bookworm), Node v26.3.1, with no `/etc/ssl/certs` and `apt-get` available.
- The `temporal-worker-controller` side is already verified working — it injects `TEMPORAL_ADDRESS`/`TEMPORAL_NAMESPACE`/`TEMPORAL_API_KEY`/`TEMPORAL_DEPLOYMENT_NAME`/`TEMPORAL_WORKER_BUILD_ID`, derives the Build ID, and creates the versioned Deployment. Only the missing CA bundle blocks the connection.
- After this merges and the publish workflow rebuilds `v1`/`v2`, the worker should connect, register, and be roll-able by the controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)